### PR TITLE
Add User SID for complete access rights checks

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Program.cs
+++ b/winPEAS/winPEASexe/winPEAS/Program.cs
@@ -83,6 +83,7 @@ namespace winPEAS
             try { 
                 Beaprint.GrayPrint("   - Creating current user groups list...");
                 WindowsIdentity identity = WindowsIdentity.GetCurrent();
+                currentUserSIDs[identity.User.ToString()] = Environment.UserName;
                 IdentityReferenceCollection currentSIDs= identity.Groups;
                 foreach (IdentityReference group in identity.Groups)
                 {
@@ -521,8 +522,12 @@ namespace winPEAS
                     Beaprint.AnsiPrint("  Current user: " + currentUserName, colorsU());
 
                     List<string> currentGroupsNames = new List<string>();
-                    foreach (KeyValuePair<string,string> g in currentUserSIDs)
+                    foreach (KeyValuePair<string, string> g in currentUserSIDs)
+                    {
+                        if (g.Key == WindowsIdentity.GetCurrent().User.ToString())
+                            continue;
                         currentGroupsNames.Add(String.IsNullOrEmpty(g.Value) ? g.Key : g.Value);
+                    }
 
                     Beaprint.AnsiPrint("  Current groups: " + String.Join(", ", currentGroupsNames), colorsU());
                     Beaprint.PrintLineSeparator();


### PR DESCRIPTION
# Issue

When performing access rights checks, WinPEAS lists all ACLs on the securable objects, and compares each ACL with `currentUserSIDs` array. Currently, this array only contains **Group** SIDs of current user, but not the user SID itself. So when an ACL is set for the current user, it is not detected by WinPEAS

# Proposed fix

Add user SID to `currentUserSIDs` array.