### PR TITLE
Add Powershell history file

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/InterestingFiles.cs
+++ b/winPEAS/winPEASexe/winPEAS/InterestingFiles.cs
@@ -437,6 +437,23 @@ namespace winPEAS
             return results;
         }
 
+        public static string GetConsoleHostHistory()
+        {
+            string result = "";
+            try
+            {
+                
+                string searchLocation = String.Format("{0}\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadline\\ConsoleHost_history.txt", Environment.GetEnvironmentVariable("USERPROFILE"));
+                if (System.IO.File.Exists(searchLocation))
+                    result = searchLocation;
+            }
+            catch (Exception ex)
+            {
+                Beaprint.GrayPrint("Error: " + ex);
+            }
+            return result;
+        }
+
         public static List<Dictionary<string, string>> GetRecycleBin()
         {
             List<Dictionary<string, string>> results = new List<Dictionary<string, string>>();

--- a/winPEAS/winPEASexe/winPEAS/Program.cs
+++ b/winPEAS/winPEASexe/winPEAS/Program.cs
@@ -1959,6 +1959,31 @@ namespace winPEAS
                 }
             }
 
+            void PrintConsoleHostHistory()
+            {
+                try
+                {
+                    Beaprint.MainPrint("Powershell History", "");
+                    string console_host_history = InterestingFiles.GetConsoleHostHistory();
+                    if (console_host_history != "")
+                    {
+                        
+                        string text = File.ReadAllText(console_host_history);
+                        List<string> credStringsRegexPowershell = new List<string>(credStringsRegex);
+                        credStringsRegexPowershell.Add("CONVERTTO-SECURESTRING");
+
+                        if (MyUtils.ContainsAnyRegex(text.ToUpper(), credStringsRegexPowershell))
+                            Beaprint.BadPrint("    " + console_host_history + " (Potential credentials found)");
+                        else
+                            System.Console.WriteLine("    " + console_host_history);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Beaprint.GrayPrint(String.Format("{0}", ex));
+                }
+            }
+
             void PrintSAMBackups()
             {
                 try
@@ -2182,6 +2207,7 @@ namespace winPEAS
             PrintSSHKeysReg();
             PrintCloudCreds();
             PrintUnattendFiles();
+            PrintConsoleHostHistory();
             PrintSAMBackups();
             PrintMcAffeSitelistFiles();
             PrintCachedGPPPassword();


### PR DESCRIPTION
Add Powershell history file check. If it exists, looks for potential credentials in the history.

![image](https://user-images.githubusercontent.com/11051803/85312738-89139c00-b4b7-11ea-874d-ed82090e6eac.png)

If **no** potential credential is found, then history file is **displayed in gray**
If potential credentialis found, then history file is **displayed in red**