### PR TITLE
Added checks to list running containers

### DIFF
--- a/linPEAS/linpeas.sh
+++ b/linPEAS/linpeas.sh
@@ -931,7 +931,7 @@ if [ "`echo $CHECKS | grep AvaSof`" ]; then
 
   #-- 1AS) Useful software
   printf $Y"[+] "$GREEN"Useful software\n"$NC
-  which nmap aws nc ncat netcat nc.traditional wget curl ping gcc g++ make gdb base64 socat python python2 python3 python2.7 python2.6 python3.6 python3.7 perl php ruby xterm doas sudo fetch docker 2>/dev/null
+  which nmap aws nc ncat netcat nc.traditional wget curl ping gcc g++ make gdb base64 socat python python2 python3 python2.7 python2.6 python3.6 python3.7 perl php ruby xterm doas sudo fetch docker lxc rkt kubectl 2>/dev/null
   echo ""
 
   #-- 2AS) Search for compilers

--- a/linPEAS/linpeas.sh
+++ b/linPEAS/linpeas.sh
@@ -896,6 +896,26 @@ if [ "`echo $CHECKS | grep SysI`" ]; then
   else echo_no
   fi
 
+  #-- ????) Containers Running
+  printf $Y"[+] "$GREEN"Any running containers? ........ "$NC
+  # Get counts of running containers for each platform
+  dockercontainers=`docker ps --format "{{.Names}}" 2>/dev/null | wc -l`
+  lxccontainers=`lxc list -c n --format csv 2>/dev/null | wc -l`
+  rktcontainers=`rkt list 2>/dev/null | tail -n +2  | wc -l`
+  if [ "$dockercontainers" -eq "0" ] && [ "$lxccontainers" -eq "0" ] && [ "$rktcontainers" -eq "0" ]; then
+    echo_no
+  else
+    containerCounts=""
+    if [ "$dockercontainers" -ne "0" ]; then containerCounts="${containerCounts}docker($dockercontainers) "; fi
+    if [ "$lxccontainers" -ne "0" ]; then containerCounts="${containerCounts}lxc($lxccontainers) "; fi
+    if [ "$rktcontainers" -ne "0" ]; then containerCounts="${containerCounts}rkt($rktcontainers) "; fi
+    echo "Yes $containerCounts" | sed "s,.*,${C}[1;31m&${C}[0m,"
+    # List any running containers
+    if [ "$dockercontainers" -ne "0" ]; then echo "Running Docker Containers" | sed "s,.*,${C}[1;31m&${C}[0m,"; docker ps | tail -n +2 2>/dev/null; echo ""; fi
+    if [ "$lxccontainers" -ne "0" ]; then echo "Running LXC Containers" | sed "s,.*,${C}[1;31m&${C}[0m,"; lxc list 2>/dev/null; echo ""; fi
+    if [ "$rktcontainers" -ne "0" ]; then echo "Running RKT Containers" | sed "s,.*,${C}[1;31m&${C}[0m,"; rkt list 2>/dev/null; echo ""; fi
+  fi
+
   echo ""
   echo ""
   if [ "$WAIT" ]; then echo "Press enter to continue"; read "asd"; fi


### PR DESCRIPTION
Added 3 more tools to interesting tools for container control: lxc, kubectl and rkt
Added check to detect currently running containers for docker, lxc and rkt

Attached screenshots example of it running

![Screenshot_20200709_143939](https://user-images.githubusercontent.com/1211162/87048208-5aa1fa80-c1f3-11ea-918d-32a9505aa719.png)

![Screenshot_20200709_144136](https://user-images.githubusercontent.com/1211162/87048222-5ece1800-c1f3-11ea-807f-3a0d57c3f397.png)

![Screenshot_20200709_144203](https://user-images.githubusercontent.com/1211162/87048230-6097db80-c1f3-11ea-911b-2a2b8b3ffcd8.png)

I wasn't sure the naming scheme for the comments so it's currently `#-- ????) Containers Running`

Thanks