### PR TITLE
3rd party device drive enum

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Program.cs
+++ b/winPEAS/winPEASexe/winPEAS/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Management;
 using System.Text.RegularExpressions;
 using System.Security.Principal;
+using System.Diagnostics;
 
 namespace winPEAS
 {
@@ -1154,12 +1155,34 @@ namespace winPEAS
                 }
             }
 
+            void PrintDeviceDrivers()
+            {
+                try
+                {
+                    Beaprint.MainPrint("Device Drivers --Non Microsoft--");
+                    // this link is not very specific, but its the best on hacktricks
+                    Beaprint.LinkPrint("https://book.hacktricks.xyz/windows/basic-cmd-for-pentesters", "Check 3rd party drivers for known vulnerabilities/rootkits.");
+                    
+                    foreach (var driver in ApplicationInfo.GetDeviceDriversNoMicrosoft())
+                    {
+                        System.Console.WriteLine(String.Format("    {0}\n    {1} [{2}]", driver.Key, driver.Value.ProductName, driver.Value.ProductVersion));
+                        Beaprint.PrintLineSeparator();
+                    }
+
+                }
+                catch (Exception ex)
+                {
+                    Beaprint.GrayPrint(String.Format("{0}", ex));
+                }
+            }
+
 
             Beaprint.GreatPrint("Applications Information");
             PrintActiveWindow();
             //PrintInstalledApps();
             PrintAutoRuns();
             PrintScheduled();
+            PrintDeviceDrivers();
         }
 
 


### PR DESCRIPTION
As suggested in #52.

The code searches for all loaded modules using a Win32 API call. Then for each module, it extracts the meta data (the same details by right clicking on the file and viewing details) from the binary and filters those provided by Microsoft. The remaining list is printed. From my tests its works fairly well and avoids the need for using WMI to extract the information, so less permissions required :sunglasses: 

I was not sure what to do about the coloring. As typically, the list of items identified would need to have there versions manually checked for vulnerabilities (or obvious suspicious paths indicating rootkits). So currently, it just prints the path, product name and version in white. Any suggestions welcome regarding colors :question:  

I suppose, ideally there could be a list of known bad drivers that could be flagged up, but I dont have a list.

As an example, for my Windows 10 VM:
![image](https://user-images.githubusercontent.com/527411/90329497-4fce4880-df9d-11ea-9e4a-157b67c924b4.png)

