### PR TITLE
Ordering SUID and SGID files by date in linpeas.sh

### DIFF
--- a/linPEAS/linpeas.sh
+++ b/linPEAS/linpeas.sh
@@ -2235,7 +2235,7 @@ if [ "`echo $CHECKS | grep IntFiles`" ]; then
   ##-- IF) SUID
   printf $Y"[+] "$GREEN"SUID - Check easy privesc, exploits and write perms\n"$NC
   printf $B"[i] "$Y"https://book.hacktricks.xyz/linux-unix/privilege-escalation#sudo-and-suid\n"$NC
-  find / -perm -4000 2>/dev/null | while read s; do
+  find / -perm /4000 -type f 2>/dev/null | xargs ls -lahtr | while read s; do
     if [ -O "$s" ]; then
       echo "You own the SUID file: $s" | sed -E "s,.*,${C}[1;31m&${C}[0m,"
     elif [ -w "$s" ]; then #If write permision, win found (no check exploits)
@@ -2259,7 +2259,7 @@ if [ "`echo $CHECKS | grep IntFiles`" ]; then
   ##-- IF) SGID
   printf $Y"[+] "$GREEN"SGID\n"$NC
   printf $B"[i] "$Y"https://book.hacktricks.xyz/linux-unix/privilege-escalation#sudo-and-suid\n"$NC
-  find / -perm -g=s -type f 2>/dev/null | while read s; do
+  find / -perm /2000 -type f 2>/dev/null | xargs ls -lahtr | while read s; do
     if [ -O "$s" ]; then
       echo "You own the SGID file: $s" | sed -E "s,.*,${C}[1;31m&${C}[0m,"
     elif [ -w $s ]; then #If write permision, win found (no check exploits)


### PR DESCRIPTION
Ordering SUID and SGID files by date helps identifying custom SUID/SGID files that are non operating system standard files. In this example, the binary `/usr/local/bin/backup` was a custom SUID binary added after OS installation, and thanks to the date ordering appears the last one:

![linpeas.sh output with SUID and SGID date ordered.](https://user-images.githubusercontent.com/6837439/95659043-d6775000-0b1e-11eb-9855-b39ee3d78fe9.png)