### PR TITLE
Fixed empty "Active Ports" output of LinPEAS, when ss is used

### DIFF
--- a/linPEAS/linpeas.sh
+++ b/linPEAS/linpeas.sh
@@ -1438,7 +1438,7 @@ if [ "`echo $CHECKS | grep Net`" ]; then
   #-- NI) Ports
   printf $Y"[+] "$GREEN"Active Ports\n"$NC
   printf $B"[i] "$Y"https://book.hacktricks.xyz/linux-unix/privilege-escalation#open-ports\n"$NC
-  (netstat -punta || ss --ntpu || (netstat -a -p tcp && netstat -a -p udp) | grep -i listen) 2>/dev/null | sed -E "s,127.0.[0-9]+.[0-9]+,${C}[1;31m&${C}[0m,"
+  (netstat -punta || ss -ntpu || (netstat -a -p tcp && netstat -a -p udp) | grep -i listen) 2>/dev/null | sed -E "s,127.0.[0-9]+.[0-9]+,${C}[1;31m&${C}[0m,"
   echo ""
 
   #-- NI) tcpdump


### PR DESCRIPTION
On systems that use `ss` instead of `netstat`, the output for "Active Ports" was empty, due to the use of 2 dashes (and thus `ss` returning an error).