### PR TITLE
Fix path to `UseWUServer`

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Checks/SystemInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/SystemInfo.cs
@@ -559,7 +559,7 @@ namespace winPEAS.Checks
                 string path = "Software\\Policies\\Microsoft\\Windows\\WindowsUpdate";
                 string path2 = "Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU";
                 string HKLM_WSUS = RegistryHelper.GetRegValue("HKLM", path, "WUServer");
-                string using_HKLM_WSUS = RegistryHelper.GetRegValue("HKLM", path, "UseWUServer");
+                string using_HKLM_WSUS = RegistryHelper.GetRegValue("HKLM", path2, "UseWUServer");
                 if (HKLM_WSUS.Contains("http://"))
                 {
                     Beaprint.BadPrint("    WSUS is using http: " + HKLM_WSUS);


### PR DESCRIPTION
Like the title says.  The correct path was already in the file, but `path` was used twice instead of using the correct `path2` for the `UseWUServer`.