### PR TITLE
Fix the bug that the k8s container cannot be detected

### DIFF
--- a/linPEAS/linpeas.sh
+++ b/linPEAS/linpeas.sh
@@ -1100,7 +1100,7 @@ if [ "`echo $CHECKS | grep SysI`" ]; then
 
   #-- SY) Container
   printf $Y"[+] "$GREEN"Is this a container? ........... "$NC
-  dockercontainer=`grep -i docker /proc/self/cgroup  2>/dev/null; find / -maxdepth 3 -name "*dockerenv*" -exec ls -la {} \; 2>/dev/null`
+  dockercontainer=`grep -i docker /proc/self/cgroup  2>/dev/null; grep -i kubepods /proc/self/cgroup  2>/dev/null; find / -maxdepth 3 -name "*dockerenv*" -exec ls -la {} \; 2>/dev/null`
   lxccontainer=`grep -qa container=lxc /proc/1/environ 2>/dev/null`
   if [ "$dockercontainer" ]; then echo "Looks like we're in a Docker container" | sed -${E} "s,.*,${C}[1;31m&${C}[0m,";
   elif [ "$lxccontainer" ]; then echo "Looks like we're in a LXC container" | sed -${E} "s,.*,${C}[1;31m&${C}[0m,";


### PR DESCRIPTION
Run linPEAS/linpeas.sh in k8s pods containers:
```
[+] Is this a container? ........... No
[+] Any running containers? ........ No
```
The cgroup infomations in k8s pods containers is different to docker container:
```
# cat /proc/self/cgroup
12:rdma:/
11:memory:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
10:freezer:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
9:devices:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
8:hugetlb:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
7:cpu,cpuacct:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
6:pids:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
5:cpuset:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
4:perf_event:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
3:net_cls,net_prio:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
2:blkio:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
1:name=systemd:/kubepods/besteffort/pod4eede96e-e976-4573-bc90-68dfe2516d3b/c3cd4e0a7993a1c155cc1bdd3326c7b1e260226d0c2c79e3e48dbc360543c768
0::/system.slice/dockerd.service
```
