### PR TITLE
Watson bug fix & smbghost vulnerabilty

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-0836.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-0836.cs
@@ -96,7 +96,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-0841.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-0841.cs
@@ -73,7 +73,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1064.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1064.cs
@@ -93,7 +93,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1130.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1130.cs
@@ -100,7 +100,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1253.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1253.cs
@@ -77,7 +77,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1315.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1315.cs
@@ -91,7 +91,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1385.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1385.cs
@@ -74,7 +74,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1388.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1388.cs
@@ -80,7 +80,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1405.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2019-1405.cs
@@ -92,7 +92,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2020-0668.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2020-0668.cs
@@ -89,7 +89,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2020-0683.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2020-0683.cs
@@ -89,7 +89,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2020-0796.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2020-0796.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using System.Collections.Generic;
+
+namespace winPEAS._3rdParty.Watson.Msrc
+{
+    internal static class CVE_2020_0796
+    {
+        private const string name = "CVE-2020-0796";
+
+        public static void Check(VulnerabilityCollection vulnerabilities, int buildNumber, List<int> installedKBs)
+        {
+            var supersedence = new List<int>();
+
+            switch (buildNumber)
+            {
+                case 18362:
+                case 18363:
+
+                    supersedence.AddRange(new int[] {
+                        4551762
+                    });
+
+                    break;
+
+                default:
+                    return;
+            }
+
+            if (!supersedence.Intersect(installedKBs).Any())
+            {
+                vulnerabilities.SetAsVulnerable(name);
+            }
+        }
+    }
+}

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2020-1013.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Msrc/CVE-2020-1013.cs
@@ -81,7 +81,7 @@ namespace winPEAS._3rdParty.Watson.Msrc
                     return;
             }
 
-            if (supersedence.Intersect(installedKBs).Any())
+            if (!supersedence.Intersect(installedKBs).Any())
             {
                 vulnerabilities.SetAsVulnerable(name);
             }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/VulnerabilityCollection.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/VulnerabilityCollection.cs
@@ -100,6 +100,10 @@ namespace winPEAS._3rdParty.Watson
                 new Vulnerability(
                     id: "CVE-2020-1013",
                     exploits: new string[] { "https://www.gosecure.net/blog/2020/09/08/wsus-attacks-part-2-cve-2020-1013-a-windows-10-local-privilege-escalation-1-day/" }
+                    ),
+                new Vulnerability(
+                    id: "CVE-2020-0796",
+                    exploits: new string[] { "https://github.com/danigargu/CVE-2020-0796 (smbghost)" }
                     )
             };
         }

--- a/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Watson.cs
+++ b/winPEAS/winPEASexe/winPEAS/3rdParty/Watson/Watson.cs
@@ -73,6 +73,7 @@ namespace winPEAS._3rdParty.Watson
             CVE_2020_0668.Check(vulnerabilities, buildNumber, installedKBs);
             CVE_2020_0683.Check(vulnerabilities, buildNumber, installedKBs);
             CVE_2020_1013.Check(vulnerabilities, buildNumber, installedKBs);
+            CVE_2020_0796.Check(vulnerabilities, buildNumber, installedKBs);
 
             // Print the results
             vulnerabilities.ShowResults();

--- a/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
+++ b/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
@@ -639,6 +639,7 @@
     <Compile Include="3rdParty\Watson\Msrc\CVE-2020-0668.cs" />
     <Compile Include="3rdParty\Watson\Msrc\CVE-2020-0683.cs" />
     <Compile Include="3rdParty\Watson\Msrc\CVE-2020-1013.cs" />
+    <Compile Include="3rdParty\Watson\Msrc\CVE-2020-0796.cs" />
     <Compile Include="3rdParty\Watson\Vulnerability.cs" />
     <Compile Include="3rdParty\Watson\VulnerabilityCollection.cs" />
     <Compile Include="3rdParty\Watson\Watson.cs" />


### PR DESCRIPTION
Watson has a serious bug in the current version marking vulnerable versions as good and non vulnerable versions as vulnerable. This was reported on the Watson repository but not resolved until now.
I don't know if it is the right choice to use this fix or wait for an official fix. Since the bug is pretty severe i wanted to give the opportunity to have this fixed right away.

I also added a check for the vulnerability CVE-2020-0796, this is were is stumbled over the bug. The check for this vulnerability has also a pending pull request on the Watson repository. 